### PR TITLE
PR to fix: Use file name as default store name for `fga store import

### DIFF
--- a/internal/storetest/read-from-input.go
+++ b/internal/storetest/read-from-input.go
@@ -19,9 +19,10 @@ package storetest
 import (
 	"fmt"
 	"os"
+	"strings"
+	"path"
 
 	"github.com/openfga/cli/internal/authorizationmodel"
-
 	"gopkg.in/yaml.v3"
 )
 
@@ -35,6 +36,7 @@ func ReadFromFile(fileName string, basePath string) (authorizationmodel.ModelFor
 	if err != nil {
 		return format, nil, fmt.Errorf("failed to read file %s due to %w", fileName, err)
 	}
+	defer testFile.Close()
 
 	decoder := yaml.NewDecoder(testFile)
 	decoder.KnownFields(true)
@@ -42,6 +44,10 @@ func ReadFromFile(fileName string, basePath string) (authorizationmodel.ModelFor
 	err = decoder.Decode(&storeData)
 	if err != nil {
 		return format, nil, fmt.Errorf("failed to unmarshal file %s due to %w", fileName, err)
+	}
+
+	if storeData.Name == "" {
+		storeData.Name = strings.TrimSuffix(path.Base(fileName), path.Ext(fileName))
 	}
 
 	format, err = storeData.LoadModel(basePath)


### PR DESCRIPTION
Closes #386.

<details>
<summary>Thought process ('trajectory')(click to expand)</summary>

**Action (0)**:
```
search_dir "store import"
```
**👀 Observation (0)**:
```
Found 5 matches for "store import" in /onthegolfcourse__cli:
/onthegolfcourse__cli/CHANGELOG.md (2 matches)
/onthegolfcourse__cli/README.md (2 matches)
/onthegolfcourse__cli/cmd/store/import.go (1 matches)
End of matches for "store import" in /onthegolfcourse__cli
```
**️🧑‍🚒 Response (0)**:
To address the issue, we need to find the part of the code that handles the `fga store import` command. This is likely to be in a file that parses command-line arguments or in a configuration file that defines the behavior of the `fga` command. Let's start by searching for files that might contain the relevant code using the `search_dir` command with the term "store import" to see if we can find where the command is implemented.

DISCUSSION
I will search for the term "store import" in the current directory to find files that might contain the relevant code for the `fga store import` command.

```
search_dir "store import"
```
**🧠 State (0)**:
```
{"open_file": "n/a", "working_dir": "/onthegolfcourse__cli"}
```
**💡 Thought (0)**:
To address the issue, we need to find the part of the code that handles the `fga store import` command. This is likely to be in a file that parses command-line arguments or in a configuration file that defines the behavior of the `fga` command. Let's start by searching for files that might contain the relevant code using the `search_dir` command with the term "store import" to see if we can find where the command is implemented.

DISCUSSION
I will search for the term "store import" in the current directory to find files that might contain the relevant code for the `fga store import` command.

---

**Action (1)**:
```
open cmd/store/import.go
```
**👀 Observation (1)**:
```
[File: /onthegolfcourse__cli/cmd/store/import.go (146 lines total)]
1:/*
2:Copyright © 2023 OpenFGA
3:
4:Licensed under the Apache License, Version 2.0 (the "License");
5:you may not use this file except in compliance with the License.
6:You may obtain a copy of the License at
7:
8:	http://www.apache.org/licenses/LICENSE-2.0
9:
10:Unless required by applicable law or agreed to in writing, software
11:distributed under the License is distributed on an "AS IS" BASIS,
12:WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
13:See the License for the specific language governing permissions and
14:limitations under the License.
15:*/
16:
17:package store
18:
19:import (
20:	"fmt"
21:	"os"
22:	"path"
23:
24:	"github.com/openfga/go-sdk/client"
25:	"github.com/spf13/cobra"
26:
27:	"github.com/openfga/cli/cmd/model"
28:	"github.com/openfga/cli/cmd/tuple"
29:	"github.com/openfga/cli/internal/authorizationmodel"
30:	"github.com/openfga/cli/internal/cmdutils"
31:	"github.com/openfga/cli/internal/fga"
32:	"github.com/openfga/cli/internal/output"
33:	"github.com/openfga/cli/internal/storetest"
34:)
35:
36:func importStore(
37:	clientConfig fga.ClientConfig,
38:	fgaClient client.SdkClient,
39:	storeData *storetest.StoreData,
40:	format authorizationmodel.ModelFormat,
41:	storeID string,
42:	maxTuplesPerWrite int,
43:	maxParallelRequests int,
44:) (*CreateStoreAndModelResponse, error) {
45:	var err error
46:	var response *CreateStoreAndModelResponse //nolint:wsl
47:	if storeID == "" {                        //nolint:wsl
48:		createStoreAndModelResponse, err := CreateStoreWithModel(clientConfig, storeData.Name, storeData.Model, format)
49:		response = createStoreAndModelResponse
50:		if err != nil { //nolint:wsl
51:			return nil, err
52:		}
53:		clientConfig.StoreID = createStoreAndModelResponse.Store.Id //nolint:wsl
54:	} else {
55:		authModel := authorizationmodel.AuthzModel{}
56:		clientConfig.StoreID = storeID
57:
58:		err = authModel.ReadModelFromString(storeData.Model, format)
59:		if err != nil {
60:			return nil, err //nolint:wrapcheck
61:		}
62:
63:		_, err := model.Write(fgaClient, authModel)
64:		if err != nil {
65:			return nil, fmt.Errorf("failed to write model due to %w", err)
66:		}
67:	}
68:
69:	fgaClient, err = clientConfig.GetFgaClient()
70:	if err != nil {
71:		return nil, fmt.Errorf("failed to initialize FGA Client due to %w", err)
72:	}
73:
74:	writeRequest := client.ClientWriteRequest{
75:		Writes: storeData.Tuples,
76:	}
77:
78:	_, err = tuple.ImportTuples(fgaClient, writeRequest, maxTuplesPerWrite, maxParallelRequests)
79:	if err != nil {
80:		return nil, err //nolint:wrapcheck
81:	}
82:
83:	return response, nil
84:}
85:
86:// importCmd represents the get command.
87:var importCmd = &cobra.Command{
88:	Use:     "import",
89:	Short:   "Import Store Data",
90:	Long:    `Import a store: updating the name, model and appending the global tuples`,
91:	Example: "fga store import --file=model.fga.yaml",
92:	RunE: func(cmd *cobra.Command, _ []string) error {
93:		var createStoreAndModelResponse *CreateStoreAndModelResponse
94:		clientConfig := cmdutils.GetClientConfig(cmd)
95:
96:		storeID, err := cmd.Flags().GetString("store-id")
97:		if err != nil {
98:			return fmt.Errorf("failed to get store-id %w", err)
99:		}
100:
(46 more lines below)
```
**️🧑‍🚒 Response (1)**:
The search results indicate that there is a file named `import.go` within the `cmd/store/` directory that likely contains the code for the `fga store import` command. Since the issue is related to the command-line behavior, this Go file is a good candidate for where the logic to default the store name to the file name should be implemented.

Let's open the `import.go` file to inspect the current implementation and see where we might make the necessary changes.

DISCUSSION
I will open the `import.go` file to inspect the code and identify where to implement the default store name behavior.

```
open cmd/store/import.go
```
**🧠 State (1)**:
```
{"open_file": "n/a", "working_dir": "/onthegolfcourse__cli"}
```
**💡 Thought (1)**:
The search results indicate that there is a file named `import.go` within the `cmd/store/` directory that likely contains the code for the `fga store import` command. Since the issue is related to the command-line behavior, this Go file is a good candidate for where the logic to default the store name to the file name should be implemented.

Let's open the `import.go` file to inspect the current implementation and see where we might make the necessary changes.

DISCUSSION
I will open the `import.go` file to inspect the code and identify where to implement the default store name behavior.

---

**Action (2)**:
```
scroll_down
```
**👀 Observation (2)**:
```
[File: /onthegolfcourse__cli/cmd/store/import.go (146 lines total)]
(46 more lines above)
47:	if storeID == "" {                        //nolint:wsl
48:		createStoreAndModelResponse, err := CreateStoreWithModel(clientConfig, storeData.Name, storeData.Model, format)
49:		response = createStoreAndModelResponse
50:		if err != nil { //nolint:wsl
51:			return nil, err
52:		}
53:		clientConfig.StoreID = createStoreAndModelResponse.Store.Id //nolint:wsl
54:	} else {
55:		authModel := authorizationmodel.AuthzModel{}
56:		clientConfig.StoreID = storeID
57:
58:		err = authModel.ReadModelFromString(storeData.Model, format)
59:		if err != nil {
60:			return nil, err //nolint:wrapcheck
61:		}
62:
63:		_, err := model.Write(fgaClient, authModel)
64:		if err != nil {
65:			return nil, fmt.Errorf("failed to write model due to %w", err)
66:		}
67:	}
68:
69:	fgaClient, err = clientConfig.GetFgaClient()
70:	if err != nil {
71:		return nil, fmt.Errorf("failed to initialize FGA Client due to %w", err)
72:	}
73:
74:	writeRequest := client.ClientWriteRequest{
75:		Writes: storeData.Tuples,
76:	}
77:
78:	_, err = tuple.ImportTuples(fgaClient, writeRequest, maxTuplesPerWrite, maxParallelRequests)
79:	if err != nil {
80:		return nil, err //nolint:wrapcheck
81:	}
82:
83:	return response, nil
84:}
85:
86:// importCmd represents the get command.
87:var importCmd = &cobra.Command{
88:	Use:     "import",
89:	Short:   "Import Store Data",
90:	Long:    `Import a store: updating the name, model and appending the global tuples`,
91:	Example: "fga store import --file=model.fga.yaml",
92:	RunE: func(cmd *cobra.Command, _ []string) error {
93:		var createStoreAndModelResponse *CreateStoreAndModelResponse
94:		clientConfig := cmdutils.GetClientConfig(cmd)
95:
96:		storeID, err := cmd.Flags().GetString("store-id")
97:		if err != nil {
98:			return fmt.Errorf("failed to get store-id %w", err)
99:		}
100:
101:		maxTuplesPerWrite, err := cmd.Flags().GetInt("max-tuples-per-write")
102:		if err != nil {
103:			return fmt.Errorf("failed to parse max tuples per write due to %w", err)
104:		}
105:
106:		maxParallelRequests, err := cmd.Flags().GetInt("max-parallel-requests")
107:		if err != nil {
108:			return fmt.Errorf("failed to parse parallel requests due to %w", err)
109:		}
110:
111:		fileName, err := cmd.Flags().GetString("file")
112:		if err != nil {
113:			return err //nolint:wrapcheck
114:		}
115:
116:		format, storeData, err := storetest.ReadFromFile(fileName, path.Dir(fileName))
117:		if err != nil {
118:			return err //nolint:wrapcheck
119:		}
120:
121:		fgaClient, err := clientConfig.GetFgaClient()
122:		if err != nil {
123:			return fmt.Errorf("failed to initialize FGA Client due to %w", err)
124:		}
125:
126:		createStoreAndModelResponse, err = importStore(clientConfig, fgaClient, storeData, format,
127:			storeID, maxTuplesPerWrite, maxParallelRequests)
128:		if err != nil {
129:			return err
130:		}
131:
132:		return output.Display(createStoreAndModelResponse)
133:	},
134:}
135:
136:func init() {
137:	importCmd.Flags().String("file", "", "File Name. The file should have the store")
138:	importCmd.Flags().String("store-id", "", "Store ID")
139:	importCmd.Flags().Int("max-tuples-per-write", tuple.MaxTuplesPerWrite, "Max tuples per write chunk.")
140:	importCmd.Flags().Int("max-parallel-requests", tuple.MaxParallelRequests, "Max number of requests to issue to the server in parallel.") //nolint:lll
141:
142:	if err := importCmd.MarkFlagRequired("file"); err != nil {
143:		fmt.Printf("error setting flag as required - %v: %v\n", "cmd/models/write", err)
144:		os.Exit(1)
145:	}
146:}
```
**️🧑‍🚒 Response (2)**:
The `import.go` file is now open, and we can see the function `importStore` which seems to handle the logic for importing a store. The issue mentions that when the `name` property is not set in the `store.fga.yaml` file, the command returns an error. We need to modify the code to use the file name as the default store name when the `name` property is not set.

Looking at the code, it seems that the `storeData.Name` is used in the `CreateStoreWithModel` function call when `storeID` is empty. This suggests that `storeData.Name` should be set to the file name if it is not already set.

Let's scroll down to see the rest of the file to find where the `storeData.Name` is being set and where we can implement the logic to default the name to the file name.

DISCUSSION
I will scroll down to view more of the `import.go` file to find where `storeData.Name` is being set and modify it to use the file name as the default store name if it's not provided.

```
scroll_down
```
**🧠 State (2)**:
```
{"open_file": "/onthegolfcourse__cli/cmd/store/import.go", "working_dir": "/onthegolfcourse__cli"}
```
**💡 Thought (2)**:
The `import.go` file is now open, and we can see the function `importStore` which seems to handle the logic for importing a store. The issue mentions that when the `name` property is not set in the `store.fga.yaml` file, the command returns an error. We need to modify the code to use the file name as the default store name when the `name` property is not set.

Looking at the code, it seems that the `storeData.Name` is used in the `CreateStoreWithModel` function call when `storeID` is empty. This suggests that `storeData.Name` should be set to the file name if it is not already set.

Let's scroll down to see the rest of the file to find where the `storeData.Name` is being set and where we can implement the logic to default the name to the file name.

DISCUSSION
I will scroll down to view more of the `import.go` file to find where `storeData.Name` is being set and modify it to use the file name as the default store name if it's not provided.

---

**Action (3)**:
```
find_file "storetest.go"
```
**👀 Observation (3)**:
```
No matches found for "storetest.go" in /onthegolfcourse__cli
```
**️🧑‍🚒 Response (3)**:
We have found the relevant section of the code in the `importCmd` variable definition. The `fileName` variable is obtained from the command-line flags, and the `storeData` is read from the file using the `storetest.ReadFromFile` function. This is likely where we need to implement the logic to use the file name as the default store name if the `name` property is not set in the `store.fga.yaml` file.

To proceed, we should inspect the `storetest.ReadFromFile` function to understand how it reads the file and sets the `storeData.Name`. If the `storeData.Name` is not being set there, we can add the logic to set it to the file name without the extension.

Let's open the file where the `storetest.ReadFromFile` function is defined to see its implementation and make the necessary changes.

DISCUSSION
I will use the `find_file` command to locate the file that contains the `storetest.ReadFromFile` function.

```
find_file "storetest.go"
```
**🧠 State (3)**:
```
{"open_file": "/onthegolfcourse__cli/cmd/store/import.go", "working_dir": "/onthegolfcourse__cli"}
```
**💡 Thought (3)**:
We have found the relevant section of the code in the `importCmd` variable definition. The `fileName` variable is obtained from the command-line flags, and the `storeData` is read from the file using the `storetest.ReadFromFile` function. This is likely where we need to implement the logic to use the file name as the default store name if the `name` property is not set in the `store.fga.yaml` file.

To proceed, we should inspect the `storetest.ReadFromFile` function to understand how it reads the file and sets the `storeData.Name`. If the `storeData.Name` is not being set there, we can add the logic to set it to the file name without the extension.

Let's open the file where the `storetest.ReadFromFile` function is defined to see its implementation and make the necessary changes.

DISCUSSION
I will use the `find_file` command to locate the file that contains the `storetest.ReadFromFile` function.

---

**Action (4)**:
```
search_dir "ReadFromFile"
```
**👀 Observation (4)**:
```
Found 7 matches for "ReadFromFile" in /onthegolfcourse__cli:
/onthegolfcourse__cli/cmd/model/test.go (1 matches)
/onthegolfcourse__cli/cmd/store/import.go (1 matches)
/onthegolfcourse__cli/internal/authorizationmodel/read-from-input.go (2 matches)
/onthegolfcourse__cli/internal/storetest/read-from-input.go (2 matches)
/onthegolfcourse__cli/internal/storetest/storedata.go (1 matches)
End of matches for "ReadFromFile" in /onthegolfcourse__cli
```
**️🧑‍🚒 Response (4)**:
It seems that the `storetest.go` file was not found in the current directory. This could mean that the file is located in a different directory or that the file name is slightly different. Since we don't have the exact file name, we can use the `search_dir` command to search for the term "ReadFromFile" to find where the function is defined.

DISCUSSION
I will search for the term "ReadFromFile" in the current directory to find the file that contains the definition of the `storetest.ReadFromFile` function.

```
search_dir "ReadFromFile"
```
**🧠 State (4)**:
```
{"open_file": "/onthegolfcourse__cli/cmd/store/import.go", "working_dir": "/onthegolfcourse__cli"}
```
**💡 Thought (4)**:
It seems that the `storetest.go` file was not found in the current directory. This could mean that the file is located in a different directory or that the file name is slightly different. Since we don't have the exact file name, we can use the `search_dir` command to search for the term "ReadFromFile" to find where the function is defined.

DISCUSSION
I will search for the term "ReadFromFile" in the current directory to find the file that contains the definition of the `storetest.ReadFromFile` function.

---

**Action (5)**:
```
open internal/storetest/read-from-input.go
```
**👀 Observation (5)**:
```
[File: /onthegolfcourse__cli/internal/storetest/read-from-input.go (58 lines total)]
1:/*
2:Copyright © 2023 OpenFGA
3:
4:Licensed under the Apache License, Version 2.0 (the "License");
5:you may not use this file except in compliance with the License.
6:You may obtain a copy of the License at
7:
8:	http://www.apache.org/licenses/LICENSE-2.0
9:
10:Unless required by applicable law or agreed to in writing, software
11:distributed under the License is distributed on an "AS IS" BASIS,
12:WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
13:See the License for the specific language governing permissions and
14:limitations under the License.
15:*/
16:
17:package storetest
18:
19:import (
20:	"fmt"
21:	"os"
22:
23:	"github.com/openfga/cli/internal/authorizationmodel"
24:
25:	"gopkg.in/yaml.v3"
26:)
27:
28:// ReadFromFile is used to read and parse the Store file.
29:func ReadFromFile(fileName string, basePath string) (authorizationmodel.ModelFormat, *StoreData, error) {
30:	format := authorizationmodel.ModelFormatDefault
31:
32:	var storeData StoreData
33:
34:	testFile, err := os.Open(fileName)
35:	if err != nil {
36:		return format, nil, fmt.Errorf("failed to read file %s due to %w", fileName, err)
37:	}
38:
39:	decoder := yaml.NewDecoder(testFile)
40:	decoder.KnownFields(true)
41:
42:	err = decoder.Decode(&storeData)
43:	if err != nil {
44:		return format, nil, fmt.Errorf("failed to unmarshal file %s due to %w", fileName, err)
45:	}
46:
47:	format, err = storeData.LoadModel(basePath)
48:	if err != nil {
49:		return format, nil, err
50:	}
51:
52:	err = storeData.LoadTuples(basePath)
53:	if err != nil {
54:		return format, nil, err
55:	}
56:
57:	return format, &storeData, nil
58:}
```
**️🧑‍🚒 Response (5)**:
The search results indicate that the `ReadFromFile` function is defined in the file `internal/storetest/read-from-input.go`. This is likely where we need to make changes to implement the default store name behavior.

Let's open the `read-from-input.go` file to inspect the implementation of the `ReadFromFile` function and modify it accordingly.

DISCUSSION
I will open the `read-from-input.go` file to inspect the `ReadFromFile` function and implement the logic for defaulting the store name to the file name if it's not provided.

```
open internal/storetest/read-from-input.go
```
**🧠 State (5)**:
```
{"open_file": "/onthegolfcourse__cli/cmd/store/import.go", "working_dir": "/onthegolfcourse__cli"}
```
**💡 Thought (5)**:
The search results indicate that the `ReadFromFile` function is defined in the file `internal/storetest/read-from-input.go`. This is likely where we need to make changes to implement the default store name behavior.

Let's open the `read-from-input.go` file to inspect the implementation of the `ReadFromFile` function and modify it accordingly.

DISCUSSION
I will open the `read-from-input.go` file to inspect the `ReadFromFile` function and implement the logic for defaulting the store name to the file name if it's not provided.

---

**Action (6)**:
```
edit 42:42
if storeData.Name == "" {
    storeData.Name = strings.TrimSuffix(path.Base(fileName), path.Ext(fileName))
}
end_of_edit
```
**👀 Observation (6)**:
```
[File: /onthegolfcourse__cli/internal/storetest/read-from-input.go (60 lines total)]
1:/*
2:Copyright © 2023 OpenFGA
3:
4:Licensed under the Apache License, Version 2.0 (the "License");
5:you may not use this file except in compliance with the License.
6:You may obtain a copy of the License at
7:
8:	http://www.apache.org/licenses/LICENSE-2.0
9:
10:Unless required by applicable law or agreed to in writing, software
11:distributed under the License is distributed on an "AS IS" BASIS,
12:WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
13:See the License for the specific language governing permissions and
14:limitations under the License.
15:*/
16:
17:package storetest
18:
19:import (
20:	"fmt"
21:	"os"
22:
23:	"github.com/openfga/cli/internal/authorizationmodel"
24:
25:	"gopkg.in/yaml.v3"
26:)
27:
28:// ReadFromFile is used to read and parse the Store file.
29:func ReadFromFile(fileName string, basePath string) (authorizationmodel.ModelFormat, *StoreData, error) {
30:	format := authorizationmodel.ModelFormatDefault
31:
32:	var storeData StoreData
33:
34:	testFile, err := os.Open(fileName)
35:	if err != nil {
36:		return format, nil, fmt.Errorf("failed to read file %s due to %w", fileName, err)
37:	}
38:
39:	decoder := yaml.NewDecoder(testFile)
40:	decoder.KnownFields(true)
41:
42:if storeData.Name == "" {
43:    storeData.Name = strings.TrimSuffix(path.Base(fileName), path.Ext(fileName))
44:}
45:	if err != nil {
46:		return format, nil, fmt.Errorf("failed to unmarshal file %s due to %w", fileName, err)
47:	}
48:
49:	format, err = storeData.LoadModel(basePath)
50:	if err != nil {
51:		return format, nil, err
52:	}
53:
54:	err = storeData.LoadTuples(basePath)
55:	if err != nil {
56:		return format, nil, err
57:	}
58:
59:	return format, &storeData, nil
60:}
File updated. Please review the changes and make sure they are correct (correct indentation, no duplicate lines, etc). Edit the file again if necessary.
```
**️🧑‍🚒 Response (6)**:
The `ReadFromFile` function in `read-from-input.go` is responsible for reading and parsing the store file. It decodes the contents of the file into a `StoreData` struct. However, there is no logic here that sets the `Name` field of `StoreData` based on the file name if it is not provided.

To implement the desired behavior, we need to add logic after the file is decoded (after line 42) to check if the `Name` field of `StoreData` is empty. If it is, we should set it to the base name of the file without the extension.

Let's edit the file to add this logic.

DISCUSSION
I will add logic to the `ReadFromFile` function to set the `Name` field of `StoreData` to the file name (without the extension) if it is not already set.

```
edit 42:42
if storeData.Name == "" {
    storeData.Name = strings.TrimSuffix(path.Base(fileName), path.Ext(fileName))
}
end_of_edit
```
**🧠 State (6)**:
```
{"open_file": "/onthegolfcourse__cli/internal/storetest/read-from-input.go", "working_dir": "/onthegolfcourse__cli"}
```
**💡 Thought (6)**:
The `ReadFromFile` function in `read-from-input.go` is responsible for reading and parsing the store file. It decodes the contents of the file into a `StoreData` struct. However, there is no logic here that sets the `Name` field of `StoreData` based on the file name if it is not provided.

To implement the desired behavior, we need to add logic after the file is decoded (after line 42) to check if the `Name` field of `StoreData` is empty. If it is, we should set it to the base name of the file without the extension.

Let's edit the file to add this logic.

DISCUSSION
I will add logic to the `ReadFromFile` function to set the `Name` field of `StoreData` to the file name (without the extension) if it is not already set.

---

**Action (7)**:
```
edit 42:58
	err = decoder.Decode(&storeData)
	if err != nil {
		return format, nil, fmt.Errorf("failed to unmarshal file %s due to %w", fileName, err)
	}

	if storeData.Name == "" {
		storeData.Name = strings.TrimSuffix(path.Base(fileName), path.Ext(fileName))
	}

	format, err = storeData.LoadModel(basePath)
	if err != nil {
		return format, nil, err
	}

	err = storeData.LoadTuples(basePath)
	if err != nil {
		return format, nil, err
	}

	return format, &storeData, nil
end_of_edit
```
**👀 Observation (7)**:
```
[File: /onthegolfcourse__cli/internal/storetest/read-from-input.go (63 lines total)]
1:/*
2:Copyright © 2023 OpenFGA
3:
4:Licensed under the Apache License, Version 2.0 (the "License");
5:you may not use this file except in compliance with the License.
6:You may obtain a copy of the License at
7:
8:	http://www.apache.org/licenses/LICENSE-2.0
9:
10:Unless required by applicable law or agreed to in writing, software
11:distributed under the License is distributed on an "AS IS" BASIS,
12:WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
13:See the License for the specific language governing permissions and
14:limitations under the License.
15:*/
16:
17:package storetest
18:
19:import (
20:	"fmt"
21:	"os"
22:
23:	"github.com/openfga/cli/internal/authorizationmodel"
24:
25:	"gopkg.in/yaml.v3"
26:)
27:
28:// ReadFromFile is used to read and parse the Store file.
29:func ReadFromFile(fileName string, basePath string) (authorizationmodel.ModelFormat, *StoreData, error) {
30:	format := authorizationmodel.ModelFormatDefault
31:
32:	var storeData StoreData
33:
34:	testFile, err := os.Open(fileName)
35:	if err != nil {
36:		return format, nil, fmt.Errorf("failed to read file %s due to %w", fileName, err)
37:	}
38:
39:	decoder := yaml.NewDecoder(testFile)
40:	decoder.KnownFields(true)
41:
42:	err = decoder.Decode(&storeData)
43:	if err != nil {
44:		return format, nil, fmt.Errorf("failed to unmarshal file %s due to %w", fileName, err)
45:	}
46:
47:	if storeData.Name == "" {
48:		storeData.Name = strings.TrimSuffix(path.Base(fileName), path.Ext(fileName))
49:	}
50:
51:	format, err = storeData.LoadModel(basePath)
52:	if err != nil {
53:		return format, nil, err
54:	}
55:
56:	err = storeData.LoadTuples(basePath)
57:	if err != nil {
58:		return format, nil, err
59:	}
60:
61:	return format, &storeData, nil
62:	return format, &storeData, nil
63:}
File updated. Please review the changes and make sure they are correct (correct indentation, no duplicate lines, etc). Edit the file again if necessary.
```
**️🧑‍🚒 Response (7)**:
It appears that the edit command was not executed correctly due to incorrect placement and indentation. The logic to set the `storeData.Name` should be placed after the `decoder.Decode(&storeData)` call, which is where the file contents are actually decoded into the `storeData` struct. Additionally, the `strings` package needs to be imported to use the `TrimSuffix` function.

Let's correct the edit by placing the new logic after the `decoder.Decode(&storeData)` call and ensuring proper indentation. We will also add the `strings` package to the import block if it's not already there.

DISCUSSION
I will re-issue the edit command with the correct placement and indentation for the logic to set the `storeData.Name`. I will also ensure that the `strings` package is imported.

```
edit 42:58
	err = decoder.Decode(&storeData)
	if err != nil {
		return format, nil, fmt.Errorf("failed to unmarshal file %s due to %w", fileName, err)
	}

	if storeData.Name == "" {
		storeData.Name = strings.TrimSuffix(path.Base(fileName), path.Ext(fileName))
	}

	format, err = storeData.LoadModel(basePath)
	if err != nil {
		return format, nil, err
	}

	err = storeData.LoadTuples(basePath)
	if err != nil {
		return format, nil, err
	}

	return format, &storeData, nil
end_of_edit
```
**🧠 State (7)**:
```
{"open_file": "/onthegolfcourse__cli/internal/storetest/read-from-input.go", "working_dir": "/onthegolfcourse__cli"}
```
**💡 Thought (7)**:
It appears that the edit command was not executed correctly due to incorrect placement and indentation. The logic to set the `storeData.Name` should be placed after the `decoder.Decode(&storeData)` call, which is where the file contents are actually decoded into the `storeData` struct. Additionally, the `strings` package needs to be imported to use the `TrimSuffix` function.

Let's correct the edit by placing the new logic after the `decoder.Decode(&storeData)` call and ensuring proper indentation. We will also add the `strings` package to the import block if it's not already there.

DISCUSSION
I will re-issue the edit command with the correct placement and indentation for the logic to set the `storeData.Name`. I will also ensure that the `strings` package is imported.

---

**Action (8)**:
```
edit 19:63
import (
	"fmt"
	"os"
	"strings"
	"path"

	"github.com/openfga/cli/internal/authorizationmodel"
	"gopkg.in/yaml.v3"
)

// ReadFromFile is used to read and parse the Store file.
func ReadFromFile(fileName string, basePath string) (authorizationmodel.ModelFormat, *StoreData, error) {
	format := authorizationmodel.ModelFormatDefault

	var storeData StoreData

	testFile, err := os.Open(fileName)
	if err != nil {
		return format, nil, fmt.Errorf("failed to read file %s due to %w", fileName, err)
	}
	defer testFile.Close()

	decoder := yaml.NewDecoder(testFile)
	decoder.KnownFields(true)

	err = decoder.Decode(&storeData)
	if err != nil {
		return format, nil, fmt.Errorf("failed to unmarshal file %s due to %w", fileName, err)
	}

	if storeData.Name == "" {
		storeData.Name = strings.TrimSuffix(path.Base(fileName), path.Ext(fileName))
	}

	format, err = storeData.LoadModel(basePath)
	if err != nil {
		return format, nil, err
	}

	err = storeData.LoadTuples(basePath)
	if err != nil {
		return format, nil, err
	}

	return format, &storeData, nil
}
end_of_edit
```
**👀 Observation (8)**:
```
[File: /onthegolfcourse__cli/internal/storetest/read-from-input.go (64 lines total)]
1:/*
2:Copyright © 2023 OpenFGA
3:
4:Licensed under the Apache License, Version 2.0 (the "License");
5:you may not use this file except in compliance with the License.
6:You may obtain a copy of the License at
7:
8:	http://www.apache.org/licenses/LICENSE-2.0
9:
10:Unless required by applicable law or agreed to in writing, software
11:distributed under the License is distributed on an "AS IS" BASIS,
12:WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
13:See the License for the specific language governing permissions and
14:limitations under the License.
15:*/
16:
17:package storetest
18:
19:import (
20:	"fmt"
21:	"os"
22:	"strings"
23:	"path"
24:
25:	"github.com/openfga/cli/internal/authorizationmodel"
26:	"gopkg.in/yaml.v3"
27:)
28:
29:// ReadFromFile is used to read and parse the Store file.
30:func ReadFromFile(fileName string, basePath string) (authorizationmodel.ModelFormat, *StoreData, error) {
31:	format := authorizationmodel.ModelFormatDefault
32:
33:	var storeData StoreData
34:
35:	testFile, err := os.Open(fileName)
36:	if err != nil {
37:		return format, nil, fmt.Errorf("failed to read file %s due to %w", fileName, err)
38:	}
39:	defer testFile.Close()
40:
41:	decoder := yaml.NewDecoder(testFile)
42:	decoder.KnownFields(true)
43:
44:	err = decoder.Decode(&storeData)
45:	if err != nil {
46:		return format, nil, fmt.Errorf("failed to unmarshal file %s due to %w", fileName, err)
47:	}
48:
49:	if storeData.Name == "" {
50:		storeData.Name = strings.TrimSuffix(path.Base(fileName), path.Ext(fileName))
51:	}
52:
53:	format, err = storeData.LoadModel(basePath)
54:	if err != nil {
55:		return format, nil, err
56:	}
57:
58:	err = storeData.LoadTuples(basePath)
59:	if err != nil {
60:		return format, nil, err
61:	}
62:
63:	return format, &storeData, nil
64:}
File updated. Please review the changes and make sure they are correct (correct indentation, no duplicate lines, etc). Edit the file again if necessary.
```
**️🧑‍🚒 Response (8)**:
The edit has been applied, but there is a duplicate line at the end of the function, which is likely a mistake. Additionally, the `strings` package is not included in the import block, which is necessary for the `TrimSuffix` function to work.

Let's correct these issues by removing the duplicate line and adding the `strings` package to the import block.

DISCUSSION
I will remove the duplicate return statement and add the `strings` package to the import block.

```
edit 19:63
import (
	"fmt"
	"os"
	"strings"
	"path"

	"github.com/openfga/cli/internal/authorizationmodel"
	"gopkg.in/yaml.v3"
)

// ReadFromFile is used to read and parse the Store file.
func ReadFromFile(fileName string, basePath string) (authorizationmodel.ModelFormat, *StoreData, error) {
	format := authorizationmodel.ModelFormatDefault

	var storeData StoreData

	testFile, err := os.Open(fileName)
	if err != nil {
		return format, nil, fmt.Errorf("failed to read file %s due to %w", fileName, err)
	}
	defer testFile.Close()

	decoder := yaml.NewDecoder(testFile)
	decoder.KnownFields(true)

	err = decoder.Decode(&storeData)
	if err != nil {
		return format, nil, fmt.Errorf("failed to unmarshal file %s due to %w", fileName, err)
	}

	if storeData.Name == "" {
		storeData.Name = strings.TrimSuffix(path.Base(fileName), path.Ext(fileName))
	}

	format, err = storeData.LoadModel(basePath)
	if err != nil {
		return format, nil, err
	}

	err = storeData.LoadTuples(basePath)
	if err != nil {
		return format, nil, err
	}

	return format, &storeData, nil
}
end_of_edit
```
**🧠 State (8)**:
```
{"open_file": "/onthegolfcourse__cli/internal/storetest/read-from-input.go", "working_dir": "/onthegolfcourse__cli"}
```
**💡 Thought (8)**:
The edit has been applied, but there is a duplicate line at the end of the function, which is likely a mistake. Additionally, the `strings` package is not included in the import block, which is necessary for the `TrimSuffix` function to work.

Let's correct these issues by removing the duplicate line and adding the `strings` package to the import block.

DISCUSSION
I will remove the duplicate return statement and add the `strings` package to the import block.

---

**Action (9)**:
```
submit
```
**👀 Observation (9)**:
```
diff --git a/internal/storetest/read-from-input.go b/internal/storetest/read-from-input.go
index 0ee9ebc..b1e95e8 100644
--- a/internal/storetest/read-from-input.go
+++ b/internal/storetest/read-from-input.go
@@ -19,9 +19,10 @@ package storetest
 import (
 	"fmt"
 	"os"
+	"strings"
+	"path"
 
 	"github.com/openfga/cli/internal/authorizationmodel"
-
 	"gopkg.in/yaml.v3"
 )
 
@@ -35,6 +36,7 @@ func ReadFromFile(fileName string, basePath string) (authorizationmodel.ModelFor
 	if err != nil {
 		return format, nil, fmt.Errorf("failed to read file %s due to %w", fileName, err)
 	}
+	defer testFile.Close()
 
 	decoder := yaml.NewDecoder(testFile)
 	decoder.KnownFields(true)
@@ -44,6 +46,10 @@ func ReadFromFile(fileName string, basePath string) (authorizationmodel.ModelFor
 		return format, nil, fmt.Errorf("failed to unmarshal file %s due to %w", fileName, err)
 	}
 
+	if storeData.Name == "" {
+		storeData.Name = strings.TrimSuffix(path.Base(fileName), path.Ext(fileName))
+	}
+
 	format, err = storeData.LoadModel(basePath)
 	if err != nil {
 		return format, nil, err
```
**️🧑‍🚒 Response (9)**:
The file has been updated correctly. The `strings` package has been added to the import block, the duplicate return statement has been removed, and the logic to set the `storeData.Name` to the file name (without the extension) if it is empty has been implemented.

With these changes, the issue described should be resolved. The `storeData.Name` will now default to the file name when the `name` property is not set in the `store.fga.yaml` file.

Before submitting the changes, it would be ideal to test the updated code to ensure that it behaves as expected. However, since we cannot run the code directly in this environment, we will proceed to submit the changes.

DISCUSSION
I will submit the changes to the code base using the `submit` command.

```
submit
```
**🧠 State (9)**:
```
{"open_file": "/onthegolfcourse__cli/internal/storetest/read-from-input.go", "working_dir": "/onthegolfcourse__cli"}
```
**💡 Thought (9)**:
The file has been updated correctly. The `strings` package has been added to the import block, the duplicate return statement has been removed, and the logic to set the `storeData.Name` to the file name (without the extension) if it is empty has been implemented.

With these changes, the issue described should be resolved. The `storeData.Name` will now default to the file name when the `name` property is not set in the `store.fga.yaml` file.

Before submitting the changes, it would be ideal to test the updated code to ensure that it behaves as expected. However, since we cannot run the code directly in this environment, we will proceed to submit the changes.

DISCUSSION
I will submit the changes to the code base using the `submit` command.
</details>